### PR TITLE
No longer over-capture TA roles

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -27,7 +27,7 @@ const GUILD_INFO = {
     icon: "a_5addd83a4328a1a9772c53d1e6c18978"
 }
 
-const restrictedRegex = /(server|verified|@everyone|umass cics|cics role bot|admin|moderator|professor|uca|ta|----)/i
+const restrictedRegex = /(server|verified|@everyone|umass cics|cics role bot|admin|moderator|professor|uca|\bta\b|----)/i
 const identityRegex = /^(he\/him|she\/her|they\/them|ze\/hir)/i
 const graduationRegex = /^(alumni|graduate student|class of \d{4})/i
 const residenceRegex = /^(zoomer|central|ohill|northeast|southwest|honors|sylvan|off-campus|rap data science|rap ethics society)/i


### PR DESCRIPTION
This regex was catching statistics roles (as they technically do include *ta*). TAs have a role that is exactly 'TA' so we can narrow the regex's grasp a bit.

Now I can add and remove my `STAT 515` role 😎 